### PR TITLE
KAFKA-14617: Fill brokerEpoch in AlterPartitionRequest

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionRequest.java
@@ -18,6 +18,7 @@
 package org.apache.kafka.common.requests;
 
 import org.apache.kafka.common.message.AlterPartitionRequestData;
+import org.apache.kafka.common.message.AlterPartitionRequestData.BrokerState;
 import org.apache.kafka.common.message.AlterPartitionResponseData;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.ByteBufferAccessor;
@@ -79,10 +80,6 @@ public class AlterPartitionRequest extends AbstractRequest {
             this.data = data;
         }
 
-        public AlterPartitionRequestData data() {
-            return this.data;
-        }
-
         @Override
         public AlterPartitionRequest build(short version) {
             if (version < 3) {
@@ -106,7 +103,7 @@ public class AlterPartitionRequest extends AbstractRequest {
         }
     }
 
-    public static List<AlterPartitionRequestData.BrokerState> newIsrToSimpleNewIsrWithBrokerEpochs(List<Integer> newIsr) {
-        return newIsr.stream().map(brokerId -> new AlterPartitionRequestData.BrokerState().setBrokerId(brokerId)).collect(Collectors.toList());
+    public static List<BrokerState> newIsrToSimpleNewIsrWithBrokerEpochs(List<Integer> newIsr) {
+        return newIsr.stream().map(brokerId -> new BrokerState().setBrokerId(brokerId)).collect(Collectors.toList());
     }
 }

--- a/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionRequest.java
+++ b/clients/src/main/java/org/apache/kafka/common/requests/AlterPartitionRequest.java
@@ -25,8 +25,8 @@ import org.apache.kafka.common.protocol.ByteBufferAccessor;
 import org.apache.kafka.common.protocol.Errors;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -85,7 +85,7 @@ public class AlterPartitionRequest extends AbstractRequest {
             if (version < 3) {
                 data.topics().forEach(topicData -> {
                     topicData.partitions().forEach(partitionData -> {
-                        List<Integer> newIsr = new LinkedList<>();
+                        List<Integer> newIsr = new ArrayList<>(partitionData.newIsrWithEpochs().size());
                         partitionData.newIsrWithEpochs().forEach(brokerState -> {
                             newIsr.add(brokerState.brokerId());
                         });

--- a/clients/src/main/resources/common/message/AlterPartitionRequest.json
+++ b/clients/src/main/resources/common/message/AlterPartitionRequest.json
@@ -21,7 +21,9 @@
   // Version 1 adds LeaderRecoveryState field (KIP-704).
   //
   // Version 2 adds TopicId field to replace TopicName field (KIP-841).
-  "validVersions": "0-2",
+  //
+  // Version 3 adds the NewIsrEpochs field and deprecates the NewIsr field (KIP-903).
+  "validVersions": "0-3",
   "flexibleVersions": "0+",
   "fields": [
     { "name": "BrokerId", "type": "int32", "versions": "0+", "entityType": "brokerId",
@@ -38,8 +40,14 @@
           "about": "The partition index" },
         { "name": "LeaderEpoch", "type": "int32", "versions": "0+",
           "about": "The leader epoch of this partition" },
-        { "name": "NewIsr", "type": "[]int32", "versions": "0+", "entityType": "brokerId",
-          "about": "The ISR for this partition" },
+        { "name": "NewIsr", "type": "[]int32", "versions": "0-2", "entityType": "brokerId",
+          "about": "The ISR for this partition. Deprecated since version 3." },
+        { "name": "NewIsrWithEpochs", "type": "[]BrokerState", "versions": "3+", "fields": [
+          { "name": "BrokerId", "type": "int32", "versions": "3+", "entityType": "brokerId",
+            "about": "The ID of the broker." },
+          { "name": "BrokerEpoch", "type": "int64", "versions": "3+", "default": "-1",
+            "about": "The epoch of the broker. It will be -1 if the epoch check is not supported." }
+        ]},
         { "name": "LeaderRecoveryState", "type": "int8", "versions": "1+", "default": "0",
           "about": "1 if the partition is recovering from an unclean leader election; 0 otherwise." },
         { "name": "PartitionEpoch", "type": "int32", "versions": "0+",

--- a/clients/src/main/resources/common/message/AlterPartitionResponse.json
+++ b/clients/src/main/resources/common/message/AlterPartitionResponse.json
@@ -21,7 +21,9 @@
   //
   // Version 2 adds TopicId field to replace TopicName field, can return the following new errors:
   // INELIGIBLE_REPLICA, NEW_LEADER_ELECTED and UNKNOWN_TOPIC_ID (KIP-841).
-  "validVersions": "0-2",
+  //
+  // Version 3 is the same as vesion 2 (KIP-903).
+  "validVersions": "0-3",
   "flexibleVersions": "0+",
   "fields": [
     { "name": "ThrottleTimeMs", "type": "int32", "versions": "0+",

--- a/clients/src/test/java/org/apache/kafka/common/requests/AlterPartitionRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/AlterPartitionRequestTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.requests;
+
+import org.apache.kafka.common.message.AlterPartitionRequestData;
+import org.apache.kafka.common.message.AlterPartitionRequestData.BrokerState;
+import org.apache.kafka.common.message.AlterPartitionRequestData.PartitionData;
+import org.apache.kafka.common.message.AlterPartitionRequestData.TopicData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.utils.annotation.ApiKeyVersionsSource;
+import org.apache.kafka.common.Uuid;
+import org.junit.jupiter.params.ParameterizedTest;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AlterPartitionRequestTest {
+    String topic = "test-topic";
+    Uuid topicId = Uuid.randomUuid();
+
+    @ParameterizedTest
+    @ApiKeyVersionsSource(apiKey = ApiKeys.ALTER_PARTITION)
+    public void testBuildAlterPartitionRequest(short version) {
+        AlterPartitionRequestData request = new AlterPartitionRequestData()
+            .setBrokerId(1)
+            .setBrokerEpoch(1);
+
+        TopicData topicData = new TopicData()
+            .setTopicId(topicId)
+            .setTopicName(topic);
+
+        List<BrokerState> newIsrWithBrokerEpoch = new LinkedList<>();
+        newIsrWithBrokerEpoch.add(new BrokerState().setBrokerId(1).setBrokerEpoch(1001));
+        newIsrWithBrokerEpoch.add(new BrokerState().setBrokerId(2).setBrokerEpoch(1002));
+        newIsrWithBrokerEpoch.add(new BrokerState().setBrokerId(3).setBrokerEpoch(1003));
+
+        topicData.setPartitions(new LinkedList<>());
+        topicData.partitions().add(new PartitionData()
+            .setPartitionIndex(0)
+            .setLeaderEpoch(1)
+            .setPartitionEpoch(10)
+            .setNewIsrWithEpochs(newIsrWithBrokerEpoch));
+
+        request.topics().add(topicData);
+
+        AlterPartitionRequest.Builder builder = new AlterPartitionRequest.Builder(request, version >= 2);
+        AlterPartitionRequest alterPartitionRequest = builder.build(version);
+        assertEquals(1, alterPartitionRequest.data().topics().size());
+        assertEquals(1, alterPartitionRequest.data().topics().get(0).partitions().size());
+        PartitionData partitionData = alterPartitionRequest.data().topics().get(0).partitions().get(0);
+        assertEquals(version >= 3, partitionData.newIsr().isEmpty());
+        assertEquals(version < 3, partitionData.newIsrWithEpochs().isEmpty());
+        if (version < 3) {
+            assertEquals(Arrays.asList(1, 2, 3), partitionData.newIsr());
+        } else {
+            assertEquals(newIsrWithBrokerEpoch, partitionData.newIsrWithEpochs());
+        }
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/requests/AlterPartitionRequestTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/AlterPartitionRequestTest.java
@@ -51,7 +51,6 @@ class AlterPartitionRequestTest {
         newIsrWithBrokerEpoch.add(new BrokerState().setBrokerId(2).setBrokerEpoch(1002));
         newIsrWithBrokerEpoch.add(new BrokerState().setBrokerId(3).setBrokerEpoch(1003));
 
-        topicData.setPartitions(new LinkedList<>());
         topicData.partitions().add(new PartitionData()
             .setPartitionIndex(0)
             .setLeaderEpoch(1)
@@ -60,7 +59,7 @@ class AlterPartitionRequestTest {
 
         request.topics().add(topicData);
 
-        AlterPartitionRequest.Builder builder = new AlterPartitionRequest.Builder(request, version >= 2);
+        AlterPartitionRequest.Builder builder = new AlterPartitionRequest.Builder(request, version > 1);
         AlterPartitionRequest alterPartitionRequest = builder.build(version);
         assertEquals(1, alterPartitionRequest.data().topics().size());
         assertEquals(1, alterPartitionRequest.data().topics().get(0).partitions().size());

--- a/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/requests/RequestResponseTest.java
@@ -1366,7 +1366,7 @@ public class RequestResponseTest {
             .setPartitionIndex(1)
             .setPartitionEpoch(2)
             .setLeaderEpoch(3)
-            .setNewIsr(asList(1, 2));
+            .setNewIsrWithEpochs(AlterPartitionRequest.newIsrToSimpleNewIsrWithBrokerEpochs(asList(1, 2)));
 
         if (version >= 1) {
             // Use the none default value; 1 - RECOVERING

--- a/core/src/main/scala/kafka/controller/KafkaController.scala
+++ b/core/src/main/scala/kafka/controller/KafkaController.scala
@@ -2324,11 +2324,10 @@ class KafkaController(val config: KafkaConfig,
 
         case Some(topicName) =>
           topicReq.partitions.forEach { partitionReq =>
-            var isr = List[Int]()
-            if (alterPartitionRequestVersion >= 3) {
-              isr = partitionReq.newIsrWithEpochs.asScala.toList.map(brokerState => brokerState.brokerId())
+            val isr = if (alterPartitionRequestVersion >= 3) {
+              partitionReq.newIsrWithEpochs.asScala.toList.map(brokerState => brokerState.brokerId())
             } else {
-              isr = partitionReq.newIsr.asScala.toList.map(_.toInt)
+              partitionReq.newIsr.asScala.toList.map(_.toInt)
             }
             partitionsToAlter.put(
               new TopicPartition(topicName, partitionReq.partitionIndex),

--- a/core/src/main/scala/kafka/server/AlterPartitionManager.scala
+++ b/core/src/main/scala/kafka/server/AlterPartitionManager.scala
@@ -283,7 +283,7 @@ class DefaultAlterPartitionManager(
         val partitionData = new AlterPartitionRequestData.PartitionData()
           .setPartitionIndex(item.topicIdPartition.partition)
           .setLeaderEpoch(item.leaderAndIsr.leaderEpoch)
-          .setNewIsrWithEpochs(AlterPartitionRequest.newIsrToSimpleNewIsrWithBrokerEpochs(item.leaderAndIsr.isr.map(Integer.valueOf).asJava))
+          .setNewIsrWithEpochs(item.leaderAndIsr.isrWithBrokerEpoch.asJava)
           .setPartitionEpoch(item.leaderAndIsr.partitionEpoch)
 
         if (metadataVersion.isLeaderRecoverySupported) {

--- a/core/src/main/scala/kafka/server/AlterPartitionManager.scala
+++ b/core/src/main/scala/kafka/server/AlterPartitionManager.scala
@@ -283,7 +283,7 @@ class DefaultAlterPartitionManager(
         val partitionData = new AlterPartitionRequestData.PartitionData()
           .setPartitionIndex(item.topicIdPartition.partition)
           .setLeaderEpoch(item.leaderAndIsr.leaderEpoch)
-          .setNewIsr(item.leaderAndIsr.isr.map(Integer.valueOf).asJava)
+          .setNewIsrWithEpochs(AlterPartitionRequest.newIsrToSimpleNewIsrWithBrokerEpochs(item.leaderAndIsr.isr.map(Integer.valueOf).asJava))
           .setPartitionEpoch(item.leaderAndIsr.partitionEpoch)
 
         if (metadataVersion.isLeaderRecoverySupported) {

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -194,7 +194,7 @@ class ReplicaManager(val config: KafkaConfig,
                      delayedDeleteRecordsPurgatoryParam: Option[DelayedOperationPurgatory[DelayedDeleteRecords]] = None,
                      delayedElectLeaderPurgatoryParam: Option[DelayedOperationPurgatory[DelayedElectLeader]] = None,
                      threadNamePrefix: Option[String] = None,
-                     brokerEpochSupplier: () => Long = () => -1
+                     val brokerEpochSupplier: () => Long = () => -1
                      ) extends Logging {
   private val metricsGroup = new KafkaMetricsGroup(this.getClass)
 

--- a/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
+++ b/core/src/main/scala/kafka/server/metadata/KRaftMetadataCache.scala
@@ -310,6 +310,11 @@ class KRaftMetadataCache(val brokerId: Int) extends MetadataCache with Logging w
     }
   }
 
+  def getAliveBrokerEpoch(brokerId: Int): Option[Long] = {
+    Option(_currentImage.cluster().broker(brokerId)).filterNot(_.fenced()).
+      map(brokerRegistration => brokerRegistration.epoch())
+  }
+
   override def getClusterMetadata(clusterId: String, listenerName: ListenerName): Cluster = {
     val image = _currentImage
     val nodes = new util.HashMap[Integer, Node]

--- a/core/src/main/scala/kafka/zk/ZkMigrationClient.scala
+++ b/core/src/main/scala/kafka/zk/ZkMigrationClient.scala
@@ -390,7 +390,7 @@ class ZkMigrationClient(
     controllerEpoch: Int
   ): (String, Array[Byte]) = {
     val path = TopicPartitionStateZNode.path(topicPartition)
-    val data = TopicPartitionStateZNode.encode(LeaderIsrAndControllerEpoch(new LeaderAndIsr(
+    val data = TopicPartitionStateZNode.encode(LeaderIsrAndControllerEpoch(LeaderAndIsr(
       partitionRegistration.leader,
       partitionRegistration.leaderEpoch,
       partitionRegistration.isr.toList,

--- a/core/src/test/scala/kafka/api/LeaderAndIsrTest.scala
+++ b/core/src/test/scala/kafka/api/LeaderAndIsrTest.scala
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test
 final class LeaderAndIsrTest {
   @Test
   def testRecoveringLeaderAndIsr(): Unit = {
-    val leaderAndIsr = LeaderAndIsr(1,  List(1, 2))
+    val leaderAndIsr = LeaderAndIsr(1, List(1, 2))
     val recoveringLeaderAndIsr = leaderAndIsr.newRecoveringLeaderAndIsr(3, List(3))
 
     assertEquals(3, recoveringLeaderAndIsr.leader)

--- a/core/src/test/scala/kafka/api/LeaderAndIsrTest.scala
+++ b/core/src/test/scala/kafka/api/LeaderAndIsrTest.scala
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test
 final class LeaderAndIsrTest {
   @Test
   def testRecoveringLeaderAndIsr(): Unit = {
-    val leaderAndIsr = LeaderAndIsr(1, List(1, 2))
+    val leaderAndIsr = LeaderAndIsr(1,  List(1, 2))
     val recoveringLeaderAndIsr = leaderAndIsr.newRecoveringLeaderAndIsr(3, List(3))
 
     assertEquals(3, recoveringLeaderAndIsr.leader)

--- a/core/src/test/scala/unit/kafka/cluster/AbstractPartitionTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/AbstractPartitionTest.scala
@@ -82,6 +82,7 @@ class AbstractPartitionTest {
       replicaLagTimeMaxMs = Defaults.ReplicaLagTimeMaxMs,
       interBrokerProtocolVersion = interBrokerProtocolVersion,
       localBrokerId = brokerId,
+      () => getDefaultBrokerEpoch(brokerId),
       time,
       alterPartitionListener,
       delayedOperations,
@@ -145,5 +146,9 @@ class AbstractPartitionTest {
     }
 
     partition
+  }
+
+  def getDefaultBrokerEpoch(brokerId: Int): Long = {
+    brokerId + 1000L
   }
 }

--- a/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/PartitionLockTest.scala
@@ -271,6 +271,7 @@ class PartitionLockTest extends Logging {
       replicaLagTimeMaxMs = kafka.server.Defaults.ReplicaLagTimeMaxMs,
       interBrokerProtocolVersion = MetadataVersion.latest,
       localBrokerId = brokerId,
+      () => 1L,
       mockTime,
       isrChangeListener,
       delayedOperations,

--- a/core/src/test/scala/unit/kafka/cluster/ReplicaTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/ReplicaTest.scala
@@ -23,8 +23,6 @@ import org.apache.kafka.storage.internals.log.LogOffsetMetadata
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.{BeforeEach, Test}
 
-import java.util.OptionalLong
-
 object ReplicaTest {
   val BrokerId: Int = 0
   val Partition: TopicPartition = new TopicPartition("foo", 0)
@@ -47,7 +45,8 @@ class ReplicaTest {
     logEndOffset: Long,
     lastCaughtUpTimeMs: Long,
     lastFetchLeaderLogEndOffset: Long,
-    lastFetchTimeMs: Long
+    lastFetchTimeMs: Long,
+    brokerEpoch: Option[Long] = Option[Long](1L)
   ): Unit = {
     val replicaState = replica.stateSnapshot
     assertEquals(logStartOffset, replicaState.logStartOffset,
@@ -60,7 +59,7 @@ class ReplicaTest {
       "Unexpected Last Fetch Leader Log End Offset")
     assertEquals(lastFetchTimeMs, replicaState.lastFetchTimeMs,
       "Unexpected Last Fetch Time")
-    assertEquals(OptionalLong.of(1L), replicaState.brokerEpoch,
+    assertEquals(brokerEpoch, replicaState.brokerEpoch,
       "Unexpected Last Fetch Time")
   }
 
@@ -128,7 +127,8 @@ class ReplicaTest {
       logEndOffset = UnifiedLog.UnknownOffset,
       lastCaughtUpTimeMs = 0L,
       lastFetchLeaderLogEndOffset = 0L,
-      lastFetchTimeMs = 0L
+      lastFetchTimeMs = 0L,
+      brokerEpoch = Option.empty
     )
   }
 
@@ -242,7 +242,8 @@ class ReplicaTest {
       logEndOffset = UnifiedLog.UnknownOffset,
       lastCaughtUpTimeMs = resetTimeMs1,
       lastFetchLeaderLogEndOffset = UnifiedLog.UnknownOffset,
-      lastFetchTimeMs = 0L
+      lastFetchTimeMs = 0L,
+      brokerEpoch = Option.empty
     )
   }
 
@@ -265,7 +266,8 @@ class ReplicaTest {
       logEndOffset = UnifiedLog.UnknownOffset,
       lastCaughtUpTimeMs = 0L,
       lastFetchLeaderLogEndOffset = UnifiedLog.UnknownOffset,
-      lastFetchTimeMs = 0L
+      lastFetchTimeMs = 0L,
+      brokerEpoch = Option.empty
     )
   }
 

--- a/core/src/test/scala/unit/kafka/cluster/ReplicaTest.scala
+++ b/core/src/test/scala/unit/kafka/cluster/ReplicaTest.scala
@@ -23,6 +23,8 @@ import org.apache.kafka.storage.internals.log.LogOffsetMetadata
 import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.{BeforeEach, Test}
 
+import java.util.OptionalLong
+
 object ReplicaTest {
   val BrokerId: Int = 0
   val Partition: TopicPartition = new TopicPartition("foo", 0)
@@ -58,6 +60,8 @@ class ReplicaTest {
       "Unexpected Last Fetch Leader Log End Offset")
     assertEquals(lastFetchTimeMs, replicaState.lastFetchTimeMs,
       "Unexpected Last Fetch Time")
+    assertEquals(OptionalLong.of(1L), replicaState.brokerEpoch,
+      "Unexpected Last Fetch Time")
   }
 
   def assertReplicaStateDoesNotChange(
@@ -86,7 +90,8 @@ class ReplicaTest {
       followerFetchOffsetMetadata = new LogOffsetMetadata(followerFetchOffset),
       followerStartOffset = followerStartOffset,
       followerFetchTimeMs = currentTimeMs,
-      leaderEndOffset = leaderEndOffset
+      leaderEndOffset = leaderEndOffset,
+      brokerEpoch = 1L
     )
     currentTimeMs
   }

--- a/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
+++ b/core/src/test/scala/unit/kafka/controller/ControllerIntegrationTest.scala
@@ -30,6 +30,7 @@ import org.apache.kafka.common.message.{AlterPartitionRequestData, AlterPartitio
 import org.apache.kafka.common.metrics.KafkaMetric
 import org.apache.kafka.common.protocol.ApiKeys
 import org.apache.kafka.common.protocol.Errors
+import org.apache.kafka.common.requests.AlterPartitionRequest
 import org.apache.kafka.common.utils.annotation.ApiKeyVersionsSource
 import org.apache.kafka.common.{ElectionType, TopicPartition, Uuid}
 import org.apache.kafka.metadata.LeaderRecoveryState
@@ -969,7 +970,7 @@ class ControllerIntegrationTest extends QuorumTestHarness {
     // on IBP >= 2.8 and 2) the AlterPartition version 2 and above is used.
     val canCallerUseTopicIds = metadataVersion.isTopicIdsSupported && alterPartitionVersion > 1
 
-    val alterPartitionRequest = new AlterPartitionRequestData()
+    val alterPartitionRequest = new AlterPartitionRequest.Builder(new AlterPartitionRequestData()
       .setBrokerId(brokerId)
       .setBrokerEpoch(brokerEpoch)
       .setTopics(Seq(new AlterPartitionRequestData.TopicData()
@@ -979,10 +980,10 @@ class ControllerIntegrationTest extends QuorumTestHarness {
           .setPartitionIndex(tp.partition)
           .setLeaderEpoch(newLeaderAndIsr.leaderEpoch)
           .setPartitionEpoch(newLeaderAndIsr.partitionEpoch)
-          .setNewIsr(newLeaderAndIsr.isr.map(Int.box).asJava)
+          .setNewIsrWithEpochs(AlterPartitionRequest.newIsrToSimpleNewIsrWithBrokerEpochs(newLeaderAndIsr.isr.map(Int.box).asJava))
           .setLeaderRecoveryState(newLeaderAndIsr.leaderRecoveryState.value)
         ).asJava)
-      ).asJava)
+      ).asJava), alterPartitionVersion > 1).build(alterPartitionVersion).data()
 
     val future = alterPartitionFuture(alterPartitionRequest, alterPartitionVersion)
 
@@ -1038,7 +1039,7 @@ class ControllerIntegrationTest extends QuorumTestHarness {
           .setPartitionIndex(tp.partition)
           .setLeaderEpoch(newLeaderAndIsr.leaderEpoch)
           .setPartitionEpoch(newLeaderAndIsr.partitionEpoch)
-          .setNewIsr(newLeaderAndIsr.isr.map(Int.box).asJava)
+          .setNewIsrWithEpochs(AlterPartitionRequest.newIsrToSimpleNewIsrWithBrokerEpochs(newLeaderAndIsr.isr.map(Int.box).asJava))
           .setLeaderRecoveryState(newLeaderAndIsr.leaderRecoveryState.value)
         ).asJava)
       ).asJava)
@@ -1089,7 +1090,7 @@ class ControllerIntegrationTest extends QuorumTestHarness {
             .setPartitionIndex(tp.partition)
             .setLeaderEpoch(oldLeaderAndIsr.leaderEpoch)
             .setPartitionEpoch(requestPartitionEpoch)
-            .setNewIsr(newIsr.map(Int.box).asJava)
+            .setNewIsrWithEpochs(AlterPartitionRequest.newIsrToSimpleNewIsrWithBrokerEpochs(newIsr.map(Int.box).asJava))
             .setLeaderRecoveryState(oldLeaderAndIsr.leaderRecoveryState.value)
           ).asJava)
         ).asJava)
@@ -1151,15 +1152,15 @@ class ControllerIntegrationTest extends QuorumTestHarness {
         .setPartitionIndex(tp.partition)
         .setLeaderEpoch(leaderAndIsr.leaderEpoch)
         .setPartitionEpoch(leaderAndIsr.partitionEpoch)
-        .setNewIsr(fullIsr.map(Int.box).asJava)
+        .setNewIsrWithEpochs(AlterPartitionRequest.newIsrToSimpleNewIsrWithBrokerEpochs(fullIsr.map(Int.box).asJava))
         .setLeaderRecoveryState(leaderAndIsr.leaderRecoveryState.value)).asJava)
     if (alterPartitionVersion > 1) requestTopic.setTopicId(topicId) else requestTopic.setTopicName(tp.topic)
 
     // Try to update ISR to contain the offline broker.
-    val alterPartitionRequest = new AlterPartitionRequestData()
+    val alterPartitionRequest = new AlterPartitionRequest.Builder(new AlterPartitionRequestData()
       .setBrokerId(controllerId)
       .setBrokerEpoch(controllerEpoch)
-      .setTopics(Seq(requestTopic).asJava)
+      .setTopics(Seq(requestTopic).asJava), alterPartitionVersion > 1).build(alterPartitionVersion).data()
 
     val future = alterPartitionFuture(alterPartitionRequest, alterPartitionVersion)
 
@@ -1484,7 +1485,7 @@ class ControllerIntegrationTest extends QuorumTestHarness {
           .setPartitionIndex(topicPartition.partition)
           .setLeaderEpoch(leaderEpoch)
           .setPartitionEpoch(partitionEpoch)
-          .setNewIsr(isr.toList.map(Int.box).asJava)
+          .setNewIsrWithEpochs(AlterPartitionRequest.newIsrToSimpleNewIsrWithBrokerEpochs(isr.toList.map(Int.box).asJava))
           .setLeaderRecoveryState(leaderRecoveryState)).asJava)).asJava)
 
     val future = alterPartitionFuture(alterPartitionRequest, if (topicIdOpt.isDefined) AlterPartitionRequestData.HIGHEST_SUPPORTED_VERSION else 1)

--- a/core/src/test/scala/unit/kafka/server/AlterPartitionManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AlterPartitionManagerTest.scala
@@ -139,7 +139,11 @@ class AlterPartitionManagerTest {
     // Make sure we sent the right request ISR={1}
     val request = capture.getValue.build()
     assertEquals(request.data().topics().size(), 1)
-    assertEquals(request.data().topics().get(0).partitions().get(0).newIsr().size(), 1)
+    if (request.version() < 3) {
+      assertEquals(request.data.topics.get(0).partitions.get(0).newIsr.size, 1)
+    } else {
+      assertEquals(request.data.topics.get(0).partitions.get(0).newIsrWithEpochs.size, 1)
+    }
   }
 
   @ParameterizedTest

--- a/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
+++ b/core/src/test/scala/unit/kafka/server/IsrExpirationTest.scala
@@ -101,7 +101,8 @@ class IsrExpirationTest {
         followerFetchOffsetMetadata = new LogOffsetMetadata(leaderLogEndOffset - 1),
         followerStartOffset = 0L,
         followerFetchTimeMs= time.milliseconds,
-        leaderEndOffset = leaderLogEndOffset)
+        leaderEndOffset = leaderLogEndOffset,
+        brokerEpoch = 1L)
     var partition0OSR = partition0.getOutOfSyncReplicas(configs.head.replicaLagTimeMaxMs)
     assertEquals(Set.empty[Int], partition0OSR, "No replica should be out of sync")
 
@@ -150,7 +151,8 @@ class IsrExpirationTest {
         followerFetchOffsetMetadata = new LogOffsetMetadata(leaderLogEndOffset - 2),
         followerStartOffset = 0L,
         followerFetchTimeMs= time.milliseconds,
-        leaderEndOffset = leaderLogEndOffset)
+        leaderEndOffset = leaderLogEndOffset,
+        brokerEpoch = 1L)
 
     // Simulate 2 fetch requests spanning more than 100 ms which do not read to the end of the log.
     // The replicas will no longer be in ISR. We do 2 fetches because we want to simulate the case where the replica is lagging but is not stuck
@@ -164,7 +166,8 @@ class IsrExpirationTest {
         followerFetchOffsetMetadata = new LogOffsetMetadata(leaderLogEndOffset - 1),
         followerStartOffset = 0L,
         followerFetchTimeMs= time.milliseconds,
-        leaderEndOffset = leaderLogEndOffset)
+        leaderEndOffset = leaderLogEndOffset,
+        brokerEpoch = 1L)
     }
     partition0OSR = partition0.getOutOfSyncReplicas(configs.head.replicaLagTimeMaxMs)
     assertEquals(Set.empty[Int], partition0OSR, "No replica should be out of sync")
@@ -181,7 +184,8 @@ class IsrExpirationTest {
         followerFetchOffsetMetadata = new LogOffsetMetadata(leaderLogEndOffset),
         followerStartOffset = 0L,
         followerFetchTimeMs= time.milliseconds,
-        leaderEndOffset = leaderLogEndOffset)
+        leaderEndOffset = leaderLogEndOffset,
+        brokerEpoch = 1L)
     }
     partition0OSR = partition0.getOutOfSyncReplicas(configs.head.replicaLagTimeMaxMs)
     assertEquals(Set.empty[Int], partition0OSR, "No replica should be out of sync")
@@ -205,7 +209,8 @@ class IsrExpirationTest {
         followerFetchOffsetMetadata = new LogOffsetMetadata(leaderLogEndOffset),
         followerStartOffset = 0L,
         followerFetchTimeMs= time.milliseconds,
-        leaderEndOffset = leaderLogEndOffset)
+        leaderEndOffset = leaderLogEndOffset,
+        brokerEpoch = 1L)
 
     var partition0OSR = partition0.getOutOfSyncReplicas(configs.head.replicaLagTimeMaxMs)
     assertEquals(Set.empty[Int], partition0OSR, "No replica should be out of sync")
@@ -241,7 +246,8 @@ class IsrExpirationTest {
         followerFetchOffsetMetadata = new LogOffsetMetadata(0L),
         followerStartOffset = 0L,
         followerFetchTimeMs= time.milliseconds,
-        leaderEndOffset = 0L)
+        leaderEndOffset = 0L,
+        brokerEpoch = 1L)
 
     // set the leader and its hw and the hw update time
     partition.leaderReplicaIdOpt = Some(leaderId)

--- a/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
@@ -703,7 +703,7 @@ class MetadataCacheTest {
 
     metadataCache.setImage(delta.apply(MetadataProvenance.EMPTY))
 
-    assertEquals(100L, metadataCache.getAliveBrokerEpoch(0).getOrElse(-1))
+    assertEquals(100L, metadataCache.getAliveBrokerEpoch(0).getOrElse(-1L))
     assertEquals(-1L, metadataCache.getAliveBrokerEpoch(1).getOrElse(-1L))
   }
 }

--- a/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/MetadataCacheTest.scala
@@ -685,4 +685,25 @@ class MetadataCacheTest {
 
     assertTrue(metadataCache.isBrokerShuttingDown(0))
   }
+
+  @Test
+  def testGetLiveBrokerEpoch(): Unit = {
+    val metadataCache = MetadataCache.kRaftMetadataCache(0)
+
+    val delta = new MetadataDelta.Builder().build()
+    delta.replay(new RegisterBrokerRecord()
+      .setBrokerId(0)
+      .setBrokerEpoch(100)
+      .setFenced(false))
+
+    delta.replay(new RegisterBrokerRecord()
+      .setBrokerId(1)
+      .setBrokerEpoch(101)
+      .setFenced(true))
+
+    metadataCache.setImage(delta.apply(MetadataProvenance.EMPTY))
+
+    assertEquals(100L, metadataCache.getAliveBrokerEpoch(0).getOrElse(-1))
+    assertEquals(-1L, metadataCache.getAliveBrokerEpoch(1).getOrElse(-1L))
+  }
 }

--- a/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
+++ b/core/src/test/scala/unit/kafka/server/ReplicaManagerConcurrencyTest.scala
@@ -231,7 +231,7 @@ class ReplicaManagerConcurrencyTest {
       val fetchParams = new FetchParams(
         ApiKeys.FETCH.latestVersion,
         replicaId,
-        1,
+        getDefaultBrokerEpoch(replicaId),
         random.nextInt(100),
         1,
         1024 * 1024,
@@ -356,6 +356,7 @@ class ReplicaManagerConcurrencyTest {
             delta.replay(new RegisterBrokerRecord()
               .setBrokerId(brokerId)
               .setFenced(false)
+              .setBrokerEpoch(getDefaultBrokerEpoch(brokerId))
             )
           }
           topic.initialize(delta)
@@ -473,6 +474,10 @@ class ReplicaManagerConcurrencyTest {
       leaderEpoch,
       partitionEpoch
     )
+  }
+
+  private def getDefaultBrokerEpoch(brokerId: Int): Long = {
+    brokerId + 100L
   }
 
 }

--- a/core/src/test/scala/unit/kafka/zk/ZkMigrationClientTest.scala
+++ b/core/src/test/scala/unit/kafka/zk/ZkMigrationClientTest.scala
@@ -144,9 +144,9 @@ class ZkMigrationClientTest extends QuorumTestHarness {
 
     val leaderAndIsrs = Map(
       new TopicPartition("test", 0) -> LeaderIsrAndControllerEpoch(
-        new LeaderAndIsr(0, 5, List(0, 1, 2), LeaderRecoveryState.RECOVERED, -1), 1),
+        LeaderAndIsr(0, 5, List(0, 1, 2), LeaderRecoveryState.RECOVERED, -1), 1),
       new TopicPartition("test", 1) -> LeaderIsrAndControllerEpoch(
-        new LeaderAndIsr(1, 5, List(1, 2, 3), LeaderRecoveryState.RECOVERED, -1), 1)
+        LeaderAndIsr(1, 5, List(1, 2, 3), LeaderRecoveryState.RECOVERED, -1), 1)
     )
     zkClient.createTopicPartitionStatesRaw(leaderAndIsrs, 0)
 

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/fetcher/ReplicaFetcherThreadBenchmark.java
@@ -178,7 +178,7 @@ public class ReplicaFetcherThreadBenchmark {
             Mockito.when(offsetCheckpoints.fetch(logDir.getAbsolutePath(), tp)).thenReturn(Option.apply(0L));
             AlterPartitionManager isrChannelManager = Mockito.mock(AlterPartitionManager.class);
             Partition partition = new Partition(tp, 100, MetadataVersion.latest(),
-                    0, Time.SYSTEM, alterPartitionListener, new DelayedOperationsMock(tp),
+                    0, () -> -1, Time.SYSTEM, alterPartitionListener, new DelayedOperationsMock(tp),
                     Mockito.mock(MetadataCache.class), logManager, isrChannelManager);
 
             partition.makeFollower(partitionState, offsetCheckpoints, topicId);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/PartitionMakeFollowerBenchmark.java
@@ -122,7 +122,7 @@ public class PartitionMakeFollowerBenchmark {
         AlterPartitionListener alterPartitionListener = Mockito.mock(AlterPartitionListener.class);
         AlterPartitionManager alterPartitionManager = Mockito.mock(AlterPartitionManager.class);
         partition = new Partition(tp, 100,
-            MetadataVersion.latest(), 0, Time.SYSTEM,
+            MetadataVersion.latest(), 0, () -> -1, Time.SYSTEM,
             alterPartitionListener, delayedOperations,
             Mockito.mock(MetadataCache.class), logManager, alterPartitionManager);
         partition.createLogIfNotExists(true, false, offsetCheckpoints, topicId);

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
@@ -160,9 +160,9 @@ public class UpdateFollowerFetchStateBenchmark {
     public void updateFollowerFetchStateBench() {
         // measure the impact of two follower fetches on the leader
         partition.updateFollowerFetchState(replica1, new LogOffsetMetadata(nextOffset, nextOffset, 0),
-                0, 1, nextOffset);
+                0, 1, nextOffset, -1);
         partition.updateFollowerFetchState(replica2, new LogOffsetMetadata(nextOffset, nextOffset, 0),
-                0, 1, nextOffset);
+                0, 1, nextOffset, -1);
         nextOffset++;
     }
 
@@ -172,8 +172,8 @@ public class UpdateFollowerFetchStateBenchmark {
         // measure the impact of two follower fetches on the leader when the follower didn't
         // end up fetching anything
         partition.updateFollowerFetchState(replica1, new LogOffsetMetadata(nextOffset, nextOffset, 0),
-                0, 1, 100);
+                0, 1, 100, -1);
         partition.updateFollowerFetchState(replica2, new LogOffsetMetadata(nextOffset, nextOffset, 0),
-                0, 1, 100);
+                0, 1, 100, -1);
     }
 }

--- a/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
+++ b/jmh-benchmarks/src/main/java/org/apache/kafka/jmh/partition/UpdateFollowerFetchStateBenchmark.java
@@ -125,7 +125,7 @@ public class UpdateFollowerFetchStateBenchmark {
         AlterPartitionListener alterPartitionListener = Mockito.mock(AlterPartitionListener.class);
         AlterPartitionManager alterPartitionManager = Mockito.mock(AlterPartitionManager.class);
         partition = new Partition(topicPartition, 100,
-                MetadataVersion.latest(), 0, Time.SYSTEM,
+                MetadataVersion.latest(), 0, () -> -1,Time.SYSTEM,
                 alterPartitionListener, delayedOperations,
                 Mockito.mock(MetadataCache.class), logManager, alterPartitionManager);
         partition.makeLeader(partitionState, offsetCheckpoints, topicId);

--- a/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
@@ -596,7 +596,7 @@ public class ClusterControlManager {
         }
     }
 
-    public long getBrokerEpoch(int brokerId) {
+    public long brokerEpoch(int brokerId) {
         BrokerRegistration registration = brokerRegistrations.get(brokerId);
         return registration == null ? -1 : registration.epoch();
     }

--- a/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
@@ -596,11 +596,6 @@ public class ClusterControlManager {
         }
     }
 
-    public long brokerEpoch(int brokerId) {
-        BrokerRegistration registration = brokerRegistrations.get(brokerId);
-        return registration == null ? -1 : registration.epoch();
-    }
-
     public void addReadyBrokersFuture(CompletableFuture<Void> future, int minBrokers) {
         readyBrokersFuture = Optional.of(new ReadyBrokersFuture(future, minBrokers));
         if (readyBrokersFuture.get().check()) {

--- a/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ClusterControlManager.java
@@ -596,6 +596,11 @@ public class ClusterControlManager {
         }
     }
 
+    public long getBrokerEpoch(int brokerId) {
+        BrokerRegistration registration = brokerRegistrations.get(brokerId);
+        return registration == null ? -1 : registration.epoch();
+    }
+
     public void addReadyBrokersFuture(CompletableFuture<Void> future, int minBrokers) {
         readyBrokersFuture = Optional.of(new ReadyBrokersFuture(future, minBrokers));
         if (readyBrokersFuture.get().check()) {

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -17,14 +17,15 @@
 
 package org.apache.kafka.controller;
 
-import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.IntPredicate;
+import java.util.stream.Collectors;
+
 import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.message.AlterPartitionRequestData;
+import org.apache.kafka.common.message.AlterPartitionRequestData.BrokerState;
 import org.apache.kafka.common.metadata.PartitionChangeRecord;
 import org.apache.kafka.metadata.LeaderRecoveryState;
 import org.apache.kafka.metadata.PartitionRegistration;
@@ -103,12 +104,9 @@ public class PartitionChangeBuilder {
         return this;
     }
 
-    public PartitionChangeBuilder setTargetIsrWithBrokerStates(List<AlterPartitionRequestData.BrokerState> targetIsrWithEpoch) {
-        Integer[] targetIsr = new Integer[targetIsrWithEpoch.size()];
-        for (int ii = 0; ii < targetIsr.length; ++ii) {
-            targetIsr[ii] = targetIsrWithEpoch.get(ii).brokerId();
-        }
-        this.targetIsr = Arrays.asList(targetIsr);
+    public PartitionChangeBuilder setTargetIsrWithBrokerStates(List<BrokerState> targetIsrWithEpoch) {
+        this.targetIsr = targetIsrWithEpoch.stream()
+            .map(brokerState -> brokerState.brokerId()).collect(Collectors.toList());
         return this;
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/PartitionChangeBuilder.java
@@ -17,12 +17,14 @@
 
 package org.apache.kafka.controller;
 
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.IntPredicate;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.message.AlterPartitionRequestData;
 import org.apache.kafka.common.metadata.PartitionChangeRecord;
 import org.apache.kafka.metadata.LeaderRecoveryState;
 import org.apache.kafka.metadata.PartitionRegistration;
@@ -98,6 +100,15 @@ public class PartitionChangeBuilder {
 
     public PartitionChangeBuilder setTargetIsr(List<Integer> targetIsr) {
         this.targetIsr = targetIsr;
+        return this;
+    }
+
+    public PartitionChangeBuilder setTargetIsrWithBrokerStates(List<AlterPartitionRequestData.BrokerState> targetIsrWithEpoch) {
+        Integer[] targetIsr = new Integer[targetIsrWithEpoch.size()];
+        for (int ii = 0; ii < targetIsr.length; ++ii) {
+            targetIsr[ii] = targetIsrWithEpoch.get(ii).brokerId();
+        }
+        this.targetIsr = Arrays.asList(targetIsr);
         return this;
     }
 

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -74,6 +74,7 @@ import org.apache.kafka.common.metadata.TopicRecord;
 import org.apache.kafka.common.metadata.UnfenceBrokerRecord;
 import org.apache.kafka.common.metadata.UnregisterBrokerRecord;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AlterPartitionRequest;
 import org.apache.kafka.common.requests.ApiError;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.metadata.BrokerHeartbeatReply;
@@ -955,6 +956,12 @@ public class ReplicationControlManager {
 
             TopicControlInfo topic = topics.get(topicId);
             for (AlterPartitionRequestData.PartitionData partitionData : topicData.partitions()) {
+                if (requestVersion < 3) {
+                    partitionData.setNewIsrWithEpochs(
+                        AlterPartitionRequest.newIsrToSimpleNewIsrWithBrokerEpochs(partitionData.newIsr())
+                    );
+                }
+
                 int partitionId = partitionData.partitionIndex();
                 PartitionRegistration partition = topic.parts.get(partitionId);
 
@@ -985,7 +992,7 @@ public class ReplicationControlManager {
                 if (configurationControl.uncleanLeaderElectionEnabledForTopic(topic.name())) {
                     builder.setElection(PartitionChangeBuilder.Election.UNCLEAN);
                 }
-                builder.setTargetIsr(partitionData.newIsr());
+                builder.setTargetIsrWithBrokerStates(partitionData.newIsrWithEpochs());
                 builder.setTargetLeaderRecoveryState(
                     LeaderRecoveryState.of(partitionData.leaderRecoveryState()));
                 Optional<ApiMessageAndVersion> record = builder.build();
@@ -1110,11 +1117,15 @@ public class ReplicationControlManager {
 
             return INVALID_UPDATE_VERSION;
         }
-        int[] newIsr = Replicas.toArray(partitionData.newIsr());
+
+        int[] newIsr = partitionData.newIsrWithEpochs().stream()
+            .map(brokerState -> brokerState.brokerId()).collect(Collectors.toList())
+            .stream().mapToInt(Integer::intValue).toArray();
+
         if (!Replicas.validateIsr(partition.replicas, newIsr)) {
             log.error("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "it specified an invalid ISR {}.", brokerId,
-                    topic.name, partitionId, partitionData.newIsr());
+                    topic.name, partitionId, partitionData.newIsrWithEpochs());
 
             return INVALID_REQUEST;
         }
@@ -1122,7 +1133,7 @@ public class ReplicationControlManager {
             // The ISR must always include the current leader.
             log.error("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "it specified an invalid ISR {} that doesn't include itself.",
-                    brokerId, topic.name, partitionId, partitionData.newIsr());
+                    brokerId, topic.name, partitionId, partitionData.newIsrWithEpochs());
 
             return INVALID_REQUEST;
         }
@@ -1131,7 +1142,7 @@ public class ReplicationControlManager {
             log.info("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "the ISR {} had more than one replica while the leader was still " +
                     "recovering from an unclean leader election {}.",
-                    brokerId, topic.name, partitionId, partitionData.newIsr(),
+                    brokerId, topic.name, partitionId, partitionData.newIsrWithEpochs(),
                     leaderRecoveryState);
 
             return INVALID_REQUEST;
@@ -1149,7 +1160,7 @@ public class ReplicationControlManager {
         if (!ineligibleReplicas.isEmpty()) {
             log.info("Rejecting AlterPartition request from node {} for {}-{} because " +
                     "it specified ineligible replicas {} in the new ISR {}.",
-                    brokerId, topic.name, partitionId, ineligibleReplicas, partitionData.newIsr());
+                    brokerId, topic.name, partitionId, ineligibleReplicas, partitionData.newIsrWithEpochs());
 
             if (requestApiVersion > 1) {
                 return INELIGIBLE_REPLICA;

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1185,6 +1185,8 @@ public class ReplicationControlManager {
             } else if (registration.fenced()) {
                 ineligibleReplicas.add(new IneligibleReplica(brokerId, "fenced"));
             } else if (brokerState.brokerEpoch() != -1 && registration.epoch() != brokerState.brokerEpoch()) {
+                // The given broker epoch should match with the broker epoch in the broker registration, except the
+                // given broker epoch is -1 which means skipping the broker epoch verification.
                 ineligibleReplicas.add(new IneligibleReplica(brokerId,
                     "broker epoch mismatch:" + brokerState.brokerEpoch() + " vs " + registration.epoch()));
             }

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1187,10 +1187,10 @@ public class ReplicationControlManager {
     private List<BrokerEpochMismatchReplica> brokerEpochMismatchReplicasForIsr(List<BrokerState> brokerStates) {
         List<BrokerEpochMismatchReplica> mismatchReplicas = new LinkedList<>();
         brokerStates.forEach(brokerState -> {
-            if (brokerState.brokerEpoch() != -1 && brokerState.brokerEpoch() != clusterControl.getBrokerEpoch(brokerState.brokerId())) {
+            if (brokerState.brokerEpoch() != -1 && brokerState.brokerEpoch() != clusterControl.brokerEpoch(brokerState.brokerId())) {
                 mismatchReplicas.add(new BrokerEpochMismatchReplica(
                     brokerState,
-                    clusterControl.getBrokerEpoch(brokerState.brokerId()))
+                    clusterControl.brokerEpoch(brokerState.brokerId()))
                 );
             }
         });

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1120,8 +1120,7 @@ public class ReplicationControlManager {
         }
 
         int[] newIsr = partitionData.newIsrWithEpochs().stream()
-            .map(brokerState -> brokerState.brokerId()).collect(Collectors.toList())
-            .stream().mapToInt(Integer::intValue).toArray();
+            .mapToInt(brokerState -> brokerState.brokerId()).toArray();
 
         if (!Replicas.validateIsr(partition.replicas, newIsr)) {
             log.error("Rejecting AlterPartition request from node {} for {}-{} because " +

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1188,7 +1188,8 @@ public class ReplicationControlManager {
                 // The given broker epoch should match with the broker epoch in the broker registration, except the
                 // given broker epoch is -1 which means skipping the broker epoch verification.
                 ineligibleReplicas.add(new IneligibleReplica(brokerId,
-                    "broker epoch mismatch:" + brokerState.brokerEpoch() + " vs " + registration.epoch()));
+                    "broker epoch mismatch: in request=" + brokerState.brokerEpoch()
+                        + " VS in registration=" + registration.epoch()));
             }
         }
         return ineligibleReplicas;

--- a/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
+++ b/metadata/src/main/java/org/apache/kafka/controller/ReplicationControlManager.java
@@ -1188,8 +1188,8 @@ public class ReplicationControlManager {
                 // The given broker epoch should match with the broker epoch in the broker registration, except the
                 // given broker epoch is -1 which means skipping the broker epoch verification.
                 ineligibleReplicas.add(new IneligibleReplica(brokerId,
-                    "broker epoch mismatch: in request=" + brokerState.brokerEpoch()
-                        + " VS in registration=" + registration.epoch()));
+                    "broker epoch mismatch: requested=" + brokerState.brokerEpoch()
+                        + " VS expected=" + registration.epoch()));
             }
         }
         return ineligibleReplicas;

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -981,6 +981,17 @@ public class ReplicationControlManagerTest {
             replicationControl, leaderId, ctx.currentBrokerEpoch(leaderId),
             topicIdPartition.topicId(), invalidRecoveryRequest);
         assertAlterPartitionResponse(invalidRecoveryResult, topicIdPartition, Errors.INVALID_REQUEST);
+
+        // Stale ISR broker epoch request.
+        PartitionData staleIsrBrokerEpochRequest = newAlterPartition(
+            replicationControl,
+            topicIdPartition,
+            asList(new BrokerState().setBrokerEpoch(99).setBrokerId(0), new BrokerState().setBrokerEpoch(101).setBrokerId(1)),
+            LeaderRecoveryState.RECOVERED);
+        ControllerResult<AlterPartitionResponseData> staleIsrBrokerEpochResult = sendAlterPartition(
+            replicationControl, leaderId, ctx.currentBrokerEpoch(leaderId),
+            topicIdPartition.topicId(), staleIsrBrokerEpochRequest);
+        assertAlterPartitionResponse(staleIsrBrokerEpochResult, topicIdPartition, INELIGIBLE_REPLICA);
     }
 
     private PartitionData newAlterPartition(
@@ -1518,8 +1529,8 @@ public class ReplicationControlManagerTest {
                         setLeaderEpoch(0).
                         setNewIsrWithEpochs(generateIsrWithTestDefaultEpoch(asList(3, 0, 2, 1)))))));
         ControllerResult<AlterPartitionResponseData> alterPartitionResult = replication.alterPartition(
-                requestContext,
-                new AlterPartitionRequest.Builder(alterPartitionRequestData, version > 1).build(version).data());
+            requestContext,
+            new AlterPartitionRequest.Builder(alterPartitionRequestData, version > 1).build(version).data());
         Errors expectedError = version > 1 ? NEW_LEADER_ELECTED : FENCED_LEADER_EPOCH;
         assertEquals(new AlterPartitionResponseData().setTopics(asList(
             new AlterPartitionResponseData.TopicData().
@@ -1610,6 +1621,75 @@ public class ReplicationControlManagerTest {
                         .setPartitionEpoch(2)
                         .setErrorCode(NONE.code()))))),
             alterPartitionResult.response());
+    }
+
+    @ParameterizedTest
+    @ApiKeyVersionsSource(apiKey = ApiKeys.ALTER_PARTITION)
+    public void testAlterPartitionShouldRejectRebootBrokers(short version) throws Exception {
+        ReplicationControlTestContext ctx = new ReplicationControlTestContext();
+        ReplicationControlManager replication = ctx.replicationControl;
+        ctx.registerBrokers(0, 1, 2, 3, 4);
+        ctx.unfenceBrokers(0, 1, 2, 3, 4);
+        Uuid fooId = ctx.createTestTopic(
+            "foo",
+            new int[][] {new int[] {1, 2, 3, 4}}
+        ).topicId();
+        ctx.alterPartition(new TopicIdPartition(fooId, 0), 1, generateIsrWithTestDefaultEpoch(asList(1, 2, 3)), LeaderRecoveryState.RECOVERED);
+
+        // First, the leader is constructing an AlterPartition request.
+        AlterPartitionRequestData alterIsrRequest = new AlterPartitionRequestData()
+            .setBrokerId(1)
+            .setBrokerEpoch(101)
+            .setTopics(asList(new TopicData()
+                .setTopicName(version <= 1 ? "foo" : "")
+                .setTopicId(version > 1 ? fooId : Uuid.ZERO_UUID)
+                .setPartitions(asList(new PartitionData()
+                    .setPartitionIndex(0)
+                    .setPartitionEpoch(1)
+                    .setLeaderEpoch(1)
+                    .setNewIsrWithEpochs(generateIsrWithTestDefaultEpoch(asList(1, 2, 3, 4)))))));
+
+        // The broker 4 has failed silently and now registers again.
+        long newEpoch = generateTestDefaultBrokerEpoch(4) + 1000;
+        RegisterBrokerRecord brokerRecord = new RegisterBrokerRecord().
+            setBrokerEpoch(newEpoch).setBrokerId(4).setRack(null);
+        brokerRecord.endPoints().add(new RegisterBrokerRecord.BrokerEndpoint().
+            setSecurityProtocol(SecurityProtocol.PLAINTEXT.id).
+            setPort((short) 9092 + 4).
+            setName("PLAINTEXT").
+            setHost("localhost"));
+        ctx.replay(Collections.singletonList(new ApiMessageAndVersion(brokerRecord, (short) 0)));
+
+        // Unfence the broker 4.
+        ControllerResult<BrokerHeartbeatReply> result = ctx.replicationControl.
+            processBrokerHeartbeat(new BrokerHeartbeatRequestData().
+                setBrokerId(4).setBrokerEpoch(newEpoch).
+                setCurrentMetadataOffset(1).
+                setWantFence(false).setWantShutDown(false), 0);
+        assertEquals(new BrokerHeartbeatReply(true, false, false, false),
+            result.response());
+        ctx.replay(result.records());
+
+        ControllerRequestContext requestContext =
+            anonymousContextFor(ApiKeys.ALTER_PARTITION, version);
+
+        ControllerResult<AlterPartitionResponseData> alterPartitionResult =
+            replication.alterPartition(requestContext, new AlterPartitionRequest.Builder(alterIsrRequest, version > 1).build(version).data());
+
+        // The late arrived AlterPartition request should be rejected when version >= 3.
+        if (version >= 3) {
+            assertEquals(
+                new AlterPartitionResponseData()
+                    .setTopics(asList(new AlterPartitionResponseData.TopicData()
+                        .setTopicName(version <= 1 ? "foo" : "")
+                        .setTopicId(version > 1 ? fooId : Uuid.ZERO_UUID)
+                        .setPartitions(asList(new AlterPartitionResponseData.PartitionData()
+                            .setPartitionIndex(0)
+                            .setErrorCode(INELIGIBLE_REPLICA.code()))))),
+                alterPartitionResult.response());
+        } else {
+            assertEquals((short) 0, alterPartitionResult.response().errorCode());
+        }
     }
 
     @ParameterizedTest

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -2381,7 +2381,7 @@ public class ReplicationControlManagerTest {
         assertEquals(expectedRecords, result.records());
     }
 
-    private static BrokerState getBrokerState(int brokerId, Long brokerEpoch) {
+    private static BrokerState brokerState(int brokerId, Long brokerEpoch) {
         return new BrokerState().setBrokerId(brokerId).setBrokerEpoch(brokerEpoch);
     }
 
@@ -2390,7 +2390,7 @@ public class ReplicationControlManagerTest {
     }
 
     private static List<BrokerState> generateIsrWithTestDefaultEpoch(List<Integer> isr) {
-        return isr.stream().map(brokerId -> getBrokerState(brokerId, generateTestDefaultBrokerEpoch(brokerId)))
+        return isr.stream().map(brokerId -> brokerState(brokerId, generateTestDefaultBrokerEpoch(brokerId)))
             .collect(Collectors.toList());
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.errors.InvalidReplicaAssignmentException;
 import org.apache.kafka.common.errors.PolicyViolationException;
 import org.apache.kafka.common.errors.StaleBrokerEpochException;
 import org.apache.kafka.common.message.AlterPartitionRequestData;
+import org.apache.kafka.common.message.AlterPartitionRequestData.BrokerState;
 import org.apache.kafka.common.message.AlterPartitionRequestData.PartitionData;
 import org.apache.kafka.common.message.AlterPartitionRequestData.TopicData;
 import org.apache.kafka.common.message.AlterPartitionResponseData;
@@ -64,6 +65,7 @@ import org.apache.kafka.common.metadata.TopicRecord;
 import org.apache.kafka.common.metadata.PartitionRecord;
 import org.apache.kafka.common.protocol.ApiKeys;
 import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.requests.AlterPartitionRequest;
 import org.apache.kafka.common.requests.ApiError;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.utils.LogContext;
@@ -311,7 +313,7 @@ public class ReplicationControlManagerTest {
         void registerBrokers(Integer... brokerIds) throws Exception {
             for (int brokerId : brokerIds) {
                 RegisterBrokerRecord brokerRecord = new RegisterBrokerRecord().
-                    setBrokerEpoch(brokerId + 100).setBrokerId(brokerId).setRack(null);
+                    setBrokerEpoch(generateTestDefaultBrokerEpoch(brokerId)).setBrokerId(brokerId).setRack(null);
                 brokerRecord.endPoints().add(new RegisterBrokerRecord.BrokerEndpoint().
                     setSecurityProtocol(SecurityProtocol.PLAINTEXT.id).
                     setPort((short) 9092 + brokerId).
@@ -324,7 +326,7 @@ public class ReplicationControlManagerTest {
         void alterPartition(
             TopicIdPartition topicIdPartition,
             int leaderId,
-            List<Integer> isr,
+            List<BrokerState> isrWithEpoch,
             LeaderRecoveryState leaderRecoveryState
         ) throws Exception {
             BrokerRegistration registration = clusterControl.brokerRegistrations().get(leaderId);
@@ -342,7 +344,7 @@ public class ReplicationControlManagerTest {
                 .setPartitionEpoch(partition.partitionEpoch)
                 .setLeaderEpoch(partition.leaderEpoch)
                 .setLeaderRecoveryState(leaderRecoveryState.value())
-                .setNewIsr(isr);
+                .setNewIsrWithEpochs(isrWithEpoch);
 
             String topicName = replicationControl.getTopic(topicIdPartition.topicId()).name();
             TopicData topicData = new TopicData()
@@ -369,7 +371,7 @@ public class ReplicationControlManagerTest {
             for (int brokerId : brokerIds) {
                 ControllerResult<BrokerHeartbeatReply> result = replicationControl.
                     processBrokerHeartbeat(new BrokerHeartbeatRequestData().
-                        setBrokerId(brokerId).setBrokerEpoch(brokerId + 100).
+                        setBrokerId(brokerId).setBrokerEpoch(generateTestDefaultBrokerEpoch(brokerId)).
                         setCurrentMetadataOffset(1).
                         setWantFence(false).setWantShutDown(false), 0);
                 assertEquals(new BrokerHeartbeatReply(true, false, false, false),
@@ -386,7 +388,7 @@ public class ReplicationControlManagerTest {
             for (int brokerId : brokerIds) {
                 BrokerRegistrationChangeRecord record = new BrokerRegistrationChangeRecord()
                     .setBrokerId(brokerId)
-                    .setBrokerEpoch(brokerId + 100)
+                    .setBrokerEpoch(generateTestDefaultBrokerEpoch(brokerId))
                     .setInControlledShutdown(BrokerRegistrationInControlledShutdownChange.IN_CONTROLLED_SHUTDOWN.value());
                 replay(singletonList(new ApiMessageAndVersion(record, (short) 1)));
             }
@@ -847,7 +849,7 @@ public class ReplicationControlManagerTest {
         assertEquals(OptionalInt.of(0), ctx.currentLeader(topicIdPartition));
         long brokerEpoch = ctx.currentBrokerEpoch(0);
         PartitionData shrinkIsrRequest = newAlterPartition(
-            replicationControl, topicIdPartition, asList(0, 1), LeaderRecoveryState.RECOVERED);
+            replicationControl, topicIdPartition, generateIsrWithTestDefaultEpoch(asList(0, 1)), LeaderRecoveryState.RECOVERED);
         ControllerResult<AlterPartitionResponseData> shrinkIsrResult = sendAlterPartition(
             replicationControl, 0, brokerEpoch, topicIdPartition.topicId(), shrinkIsrRequest);
         AlterPartitionResponseData.PartitionData shrinkIsrResponse = assertAlterPartitionResponse(
@@ -855,7 +857,7 @@ public class ReplicationControlManagerTest {
         assertConsistentAlterPartitionResponse(replicationControl, topicIdPartition, shrinkIsrResponse);
 
         PartitionData expandIsrRequest = newAlterPartition(
-            replicationControl, topicIdPartition, asList(0, 1, 2), LeaderRecoveryState.RECOVERED);
+            replicationControl, topicIdPartition, generateIsrWithTestDefaultEpoch(asList(0, 1, 2)), LeaderRecoveryState.RECOVERED);
         ControllerResult<AlterPartitionResponseData> expandIsrResult = sendAlterPartition(
             replicationControl, 0, brokerEpoch, topicIdPartition.topicId(), expandIsrRequest);
         AlterPartitionResponseData.PartitionData expandIsrResponse = assertAlterPartitionResponse(
@@ -918,7 +920,7 @@ public class ReplicationControlManagerTest {
 
         // Invalid leader
         PartitionData invalidLeaderRequest = newAlterPartition(
-            replicationControl, topicIdPartition, asList(0, 1), LeaderRecoveryState.RECOVERED);
+            replicationControl, topicIdPartition, generateIsrWithTestDefaultEpoch(asList(0, 1)), LeaderRecoveryState.RECOVERED);
         ControllerResult<AlterPartitionResponseData> invalidLeaderResult = sendAlterPartition(
             replicationControl, notLeaderId, ctx.currentBrokerEpoch(notLeaderId),
             topicIdPartition.topicId(), invalidLeaderRequest);
@@ -926,13 +928,13 @@ public class ReplicationControlManagerTest {
 
         // Stale broker epoch
         PartitionData invalidBrokerEpochRequest = newAlterPartition(
-            replicationControl, topicIdPartition, asList(0, 1), LeaderRecoveryState.RECOVERED);
+            replicationControl, topicIdPartition, generateIsrWithTestDefaultEpoch(asList(0, 1)), LeaderRecoveryState.RECOVERED);
         assertThrows(StaleBrokerEpochException.class, () -> sendAlterPartition(
             replicationControl, leaderId, brokerEpoch - 1, topicIdPartition.topicId(), invalidBrokerEpochRequest));
 
         // Invalid leader epoch
         PartitionData invalidLeaderEpochRequest = newAlterPartition(
-            replicationControl, topicIdPartition, asList(0, 1), LeaderRecoveryState.RECOVERED);
+            replicationControl, topicIdPartition, generateIsrWithTestDefaultEpoch(asList(0, 1)), LeaderRecoveryState.RECOVERED);
         invalidLeaderEpochRequest.setLeaderEpoch(500);
         ControllerResult<AlterPartitionResponseData> invalidLeaderEpochResult = sendAlterPartition(
             replicationControl, leaderId, ctx.currentBrokerEpoch(leaderId),
@@ -941,7 +943,7 @@ public class ReplicationControlManagerTest {
 
         // Invalid partition epoch
         PartitionData invalidPartitionEpochRequest = newAlterPartition(
-            replicationControl, topicIdPartition, asList(0, 1), LeaderRecoveryState.RECOVERED);
+            replicationControl, topicIdPartition, generateIsrWithTestDefaultEpoch(asList(0, 1)), LeaderRecoveryState.RECOVERED);
         invalidPartitionEpochRequest.setPartitionEpoch(500);
         ControllerResult<AlterPartitionResponseData> invalidPartitionEpochResult = sendAlterPartition(
             replicationControl, leaderId, ctx.currentBrokerEpoch(leaderId),
@@ -950,7 +952,7 @@ public class ReplicationControlManagerTest {
 
         // Invalid ISR (3 is not a valid replica)
         PartitionData invalidIsrRequest1 = newAlterPartition(
-            replicationControl, topicIdPartition, asList(0, 1, 3), LeaderRecoveryState.RECOVERED);
+            replicationControl, topicIdPartition, generateIsrWithTestDefaultEpoch(asList(0, 1, 3)), LeaderRecoveryState.RECOVERED);
         ControllerResult<AlterPartitionResponseData> invalidIsrResult1 = sendAlterPartition(
             replicationControl, leaderId, ctx.currentBrokerEpoch(leaderId),
             topicIdPartition.topicId(), invalidIsrRequest1);
@@ -958,7 +960,7 @@ public class ReplicationControlManagerTest {
 
         // Invalid ISR (does not include leader 0)
         PartitionData invalidIsrRequest2 = newAlterPartition(
-            replicationControl, topicIdPartition, asList(1, 2), LeaderRecoveryState.RECOVERED);
+            replicationControl, topicIdPartition, generateIsrWithTestDefaultEpoch(asList(1, 2)), LeaderRecoveryState.RECOVERED);
         ControllerResult<AlterPartitionResponseData> invalidIsrResult2 = sendAlterPartition(
             replicationControl, leaderId, ctx.currentBrokerEpoch(leaderId),
             topicIdPartition.topicId(), invalidIsrRequest2);
@@ -966,7 +968,7 @@ public class ReplicationControlManagerTest {
 
         // Invalid ISR length and recovery state
         PartitionData invalidIsrRecoveryRequest = newAlterPartition(
-            replicationControl, topicIdPartition, asList(0, 1), LeaderRecoveryState.RECOVERING);
+            replicationControl, topicIdPartition, generateIsrWithTestDefaultEpoch(asList(0, 1)), LeaderRecoveryState.RECOVERING);
         ControllerResult<AlterPartitionResponseData> invalidIsrRecoveryResult = sendAlterPartition(
             replicationControl, leaderId, ctx.currentBrokerEpoch(leaderId),
             topicIdPartition.topicId(), invalidIsrRecoveryRequest);
@@ -974,7 +976,7 @@ public class ReplicationControlManagerTest {
 
         // Invalid recovery state transition from RECOVERED to RECOVERING
         PartitionData invalidRecoveryRequest = newAlterPartition(
-            replicationControl, topicIdPartition, asList(0), LeaderRecoveryState.RECOVERING);
+            replicationControl, topicIdPartition, generateIsrWithTestDefaultEpoch(asList(0)), LeaderRecoveryState.RECOVERING);
         ControllerResult<AlterPartitionResponseData> invalidRecoveryResult = sendAlterPartition(
             replicationControl, leaderId, ctx.currentBrokerEpoch(leaderId),
             topicIdPartition.topicId(), invalidRecoveryRequest);
@@ -984,7 +986,7 @@ public class ReplicationControlManagerTest {
     private PartitionData newAlterPartition(
         ReplicationControlManager replicationControl,
         TopicIdPartition topicIdPartition,
-        List<Integer> newIsr,
+        List<BrokerState> newIsrWithEpoch,
         LeaderRecoveryState leaderRecoveryState
     ) {
         PartitionRegistration partitionControl =
@@ -993,7 +995,7 @@ public class ReplicationControlManagerTest {
             .setPartitionIndex(0)
             .setLeaderEpoch(partitionControl.leaderEpoch)
             .setPartitionEpoch(partitionControl.partitionEpoch)
-            .setNewIsr(newIsr)
+            .setNewIsrWithEpochs(newIsrWithEpoch)
             .setLeaderRecoveryState(leaderRecoveryState.value());
     }
 
@@ -1506,9 +1508,7 @@ public class ReplicationControlManagerTest {
         log.info("running final alterPartition...");
         ControllerRequestContext requestContext =
             anonymousContextFor(ApiKeys.ALTER_PARTITION, version);
-        ControllerResult<AlterPartitionResponseData> alterPartitionResult = replication.alterPartition(
-            requestContext,
-            new AlterPartitionRequestData().setBrokerId(3).setBrokerEpoch(103).
+        AlterPartitionRequestData alterPartitionRequestData = new AlterPartitionRequestData().setBrokerId(3).setBrokerEpoch(103).
                 setTopics(asList(new TopicData().
                     setTopicName(version <= 1 ? "foo" : "").
                     setTopicId(version > 1 ? fooId : Uuid.ZERO_UUID).
@@ -1516,7 +1516,10 @@ public class ReplicationControlManagerTest {
                         setPartitionIndex(1).
                         setPartitionEpoch(1).
                         setLeaderEpoch(0).
-                        setNewIsr(asList(3, 0, 2, 1)))))));
+                        setNewIsrWithEpochs(generateIsrWithTestDefaultEpoch(asList(3, 0, 2, 1)))))));
+        ControllerResult<AlterPartitionResponseData> alterPartitionResult = replication.alterPartition(
+                requestContext,
+                new AlterPartitionRequest.Builder(alterPartitionRequestData, version > 1).build(version).data());
         Errors expectedError = version > 1 ? NEW_LEADER_ELECTED : FENCED_LEADER_EPOCH;
         assertEquals(new AlterPartitionResponseData().setTopics(asList(
             new AlterPartitionResponseData.TopicData().
@@ -1569,13 +1572,13 @@ public class ReplicationControlManagerTest {
                     .setPartitionIndex(0)
                     .setPartitionEpoch(1)
                     .setLeaderEpoch(1)
-                    .setNewIsr(asList(1, 2, 3, 4))))));
+                    .setNewIsrWithEpochs(generateIsrWithTestDefaultEpoch(asList(1, 2, 3, 4)))))));
 
         ControllerRequestContext requestContext =
             anonymousContextFor(ApiKeys.ALTER_PARTITION, version);
 
         ControllerResult<AlterPartitionResponseData> alterPartitionResult =
-            replication.alterPartition(requestContext, alterIsrRequest);
+            replication.alterPartition(requestContext, new AlterPartitionRequest.Builder(alterIsrRequest, version > 1).build(version).data());
 
         Errors expectedError = version <= 1 ? OPERATION_NOT_ATTEMPTED : INELIGIBLE_REPLICA;
         assertEquals(
@@ -1645,13 +1648,13 @@ public class ReplicationControlManagerTest {
                     .setPartitionIndex(0)
                     .setPartitionEpoch(0)
                     .setLeaderEpoch(0)
-                    .setNewIsr(asList(1, 2, 3, 4))))));
+                    .setNewIsrWithEpochs(generateIsrWithTestDefaultEpoch(asList(1, 2, 3, 4)))))));
 
         ControllerRequestContext requestContext =
             anonymousContextFor(ApiKeys.ALTER_PARTITION, version);
 
         ControllerResult<AlterPartitionResponseData> alterPartitionResult =
-            replication.alterPartition(requestContext, alterIsrRequest);
+            replication.alterPartition(requestContext, new AlterPartitionRequest.Builder(alterIsrRequest, version > 1).build(version).data());
 
         Errors expectedError = version <= 1 ? OPERATION_NOT_ATTEMPTED : INELIGIBLE_REPLICA;
         assertEquals(
@@ -1743,7 +1746,7 @@ public class ReplicationControlManagerTest {
             new AlterPartitionRequestData().setBrokerId(4).setBrokerEpoch(104).
                 setTopics(asList(new TopicData().setTopicId(barId).setPartitions(asList(
                     new PartitionData().setPartitionIndex(0).setPartitionEpoch(2).
-                        setLeaderEpoch(1).setNewIsr(asList(4, 1, 2, 0)))))));
+                        setLeaderEpoch(1).setNewIsrWithEpochs(generateIsrWithTestDefaultEpoch(asList(4, 1, 2, 0))))))));
         assertEquals(new AlterPartitionResponseData().setTopics(asList(
             new AlterPartitionResponseData.TopicData().setTopicId(barId).setPartitions(asList(
                 new AlterPartitionResponseData.PartitionData().
@@ -1872,7 +1875,7 @@ public class ReplicationControlManagerTest {
 
         // Bring 2 back into the ISR for partition 1. This allows us to verify that
         // preferred election does not occur as a result of the unclean election request.
-        ctx.alterPartition(partition1, 4, asList(2, 4), LeaderRecoveryState.RECOVERED);
+        ctx.alterPartition(partition1, 4, generateIsrWithTestDefaultEpoch(asList(2, 4)), LeaderRecoveryState.RECOVERED);
 
         ControllerResult<ElectLeadersResponseData> result = replication.electLeaders(request);
         assertEquals(1, result.records().size());
@@ -2044,10 +2047,10 @@ public class ReplicationControlManagerTest {
                     setPartitions(asList(
                         new AlterPartitionRequestData.PartitionData().
                             setPartitionIndex(0).setPartitionEpoch(0).
-                            setLeaderEpoch(0).setNewIsr(asList(1, 2, 3)),
+                            setLeaderEpoch(0).setNewIsrWithEpochs(generateIsrWithTestDefaultEpoch(asList(1, 2, 3))),
                         new AlterPartitionRequestData.PartitionData().
                             setPartitionIndex(2).setPartitionEpoch(0).
-                            setLeaderEpoch(0).setNewIsr(asList(0, 2, 1)))))));
+                            setLeaderEpoch(0).setNewIsrWithEpochs(generateIsrWithTestDefaultEpoch(asList(0, 2, 1))))))));
         assertEquals(new AlterPartitionResponseData().setTopics(asList(
             new AlterPartitionResponseData.TopicData().setTopicId(fooId).setPartitions(asList(
                 new AlterPartitionResponseData.PartitionData().
@@ -2129,7 +2132,7 @@ public class ReplicationControlManagerTest {
                 setTopics(asList(new AlterPartitionRequestData.TopicData().setTopicId(fooId).
                     setPartitions(asList(new AlterPartitionRequestData.PartitionData().
                         setPartitionIndex(0).setPartitionEpoch(0).
-                        setLeaderEpoch(0).setNewIsr(asList(1, 2, 3)))))));
+                        setLeaderEpoch(0).setNewIsrWithEpochs(generateIsrWithTestDefaultEpoch(asList(1, 2, 3))))))));
         assertEquals(new AlterPartitionResponseData().setTopics(asList(
             new AlterPartitionResponseData.TopicData().setTopicId(fooId).setPartitions(asList(
                 new AlterPartitionResponseData.PartitionData().
@@ -2161,7 +2164,7 @@ public class ReplicationControlManagerTest {
                 setTopics(asList(new AlterPartitionRequestData.TopicData().setTopicId(fooId).
                     setPartitions(asList(new AlterPartitionRequestData.PartitionData().
                         setPartitionIndex(2).setPartitionEpoch(0).
-                        setLeaderEpoch(0).setNewIsr(asList(0, 2, 1)))))));
+                        setLeaderEpoch(0).setNewIsrWithEpochs(generateIsrWithTestDefaultEpoch(asList(0, 2, 1))))))));
         assertEquals(new AlterPartitionResponseData().setTopics(asList(
             new AlterPartitionResponseData.TopicData().setTopicId(fooId).setPartitions(asList(
                 new AlterPartitionResponseData.PartitionData().
@@ -2296,5 +2299,18 @@ public class ReplicationControlManagerTest {
             (short) 0));
 
         assertEquals(expectedRecords, result.records());
+    }
+
+    private static BrokerState getBrokerState(int brokerId, Long brokerEpoch) {
+        return new BrokerState().setBrokerId(brokerId).setBrokerEpoch(brokerEpoch);
+    }
+
+    private static Long generateTestDefaultBrokerEpoch(int brokerId) {
+        return brokerId + 100L;
+    }
+
+    private static List<BrokerState> generateIsrWithTestDefaultEpoch(List<Integer> isr) {
+        return isr.stream().map(brokerId -> getBrokerState(brokerId, generateTestDefaultBrokerEpoch(brokerId)))
+            .collect(Collectors.toList());
     }
 }

--- a/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
+++ b/metadata/src/test/java/org/apache/kafka/controller/ReplicationControlManagerTest.java
@@ -1519,7 +1519,9 @@ public class ReplicationControlManagerTest {
         log.info("running final alterPartition...");
         ControllerRequestContext requestContext =
             anonymousContextFor(ApiKeys.ALTER_PARTITION, version);
-        AlterPartitionRequestData alterPartitionRequestData = new AlterPartitionRequestData().setBrokerId(3).setBrokerEpoch(103).
+        AlterPartitionRequestData alterPartitionRequestData = new AlterPartitionRequestData().
+                setBrokerId(3).
+                setBrokerEpoch(103).
                 setTopics(asList(new TopicData().
                     setTopicName(version <= 1 ? "foo" : "").
                     setTopicId(version > 1 ? fooId : Uuid.ZERO_UUID).
@@ -1625,7 +1627,7 @@ public class ReplicationControlManagerTest {
 
     @ParameterizedTest
     @ApiKeyVersionsSource(apiKey = ApiKeys.ALTER_PARTITION)
-    public void testAlterPartitionShouldRejectRebootBrokers(short version) throws Exception {
+    public void testAlterPartitionShouldRejectBrokersWithStaleEpoch(short version) throws Exception {
         ReplicationControlTestContext ctx = new ReplicationControlTestContext();
         ReplicationControlManager replication = ctx.replicationControl;
         ctx.registerBrokers(0, 1, 2, 3, 4);
@@ -1637,17 +1639,17 @@ public class ReplicationControlManagerTest {
         ctx.alterPartition(new TopicIdPartition(fooId, 0), 1, generateIsrWithTestDefaultEpoch(asList(1, 2, 3)), LeaderRecoveryState.RECOVERED);
 
         // First, the leader is constructing an AlterPartition request.
-        AlterPartitionRequestData alterIsrRequest = new AlterPartitionRequestData()
-            .setBrokerId(1)
-            .setBrokerEpoch(101)
-            .setTopics(asList(new TopicData()
-                .setTopicName(version <= 1 ? "foo" : "")
-                .setTopicId(version > 1 ? fooId : Uuid.ZERO_UUID)
-                .setPartitions(asList(new PartitionData()
-                    .setPartitionIndex(0)
-                    .setPartitionEpoch(1)
-                    .setLeaderEpoch(1)
-                    .setNewIsrWithEpochs(generateIsrWithTestDefaultEpoch(asList(1, 2, 3, 4)))))));
+        AlterPartitionRequestData alterIsrRequest = new AlterPartitionRequestData().
+            setBrokerId(1).
+            setBrokerEpoch(101).
+            setTopics(asList(new TopicData().
+                setTopicName(version <= 1 ? "foo" : "").
+                setTopicId(version > 1 ? fooId : Uuid.ZERO_UUID).
+                setPartitions(asList(new PartitionData().
+                    setPartitionIndex(0).
+                    setPartitionEpoch(1).
+                    setLeaderEpoch(1).
+                    setNewIsrWithEpochs(generateIsrWithTestDefaultEpoch(asList(1, 2, 3, 4)))))));
 
         // The broker 4 has failed silently and now registers again.
         long newEpoch = generateTestDefaultBrokerEpoch(4) + 1000;
@@ -1679,16 +1681,16 @@ public class ReplicationControlManagerTest {
         // The late arrived AlterPartition request should be rejected when version >= 3.
         if (version >= 3) {
             assertEquals(
-                new AlterPartitionResponseData()
-                    .setTopics(asList(new AlterPartitionResponseData.TopicData()
-                        .setTopicName(version <= 1 ? "foo" : "")
-                        .setTopicId(version > 1 ? fooId : Uuid.ZERO_UUID)
-                        .setPartitions(asList(new AlterPartitionResponseData.PartitionData()
-                            .setPartitionIndex(0)
-                            .setErrorCode(INELIGIBLE_REPLICA.code()))))),
+                new AlterPartitionResponseData().
+                    setTopics(asList(new AlterPartitionResponseData.TopicData().
+                        setTopicName(version <= 1 ? "foo" : "").
+                        setTopicId(version > 1 ? fooId : Uuid.ZERO_UUID).
+                        setPartitions(asList(new AlterPartitionResponseData.PartitionData().
+                            setPartitionIndex(0).
+                            setErrorCode(INELIGIBLE_REPLICA.code()))))),
                 alterPartitionResult.response());
         } else {
-            assertEquals((short) 0, alterPartitionResult.response().errorCode());
+            assertEquals(NONE.code(), alterPartitionResult.response().errorCode());
         }
     }
 


### PR DESCRIPTION
As the third part of the [KIP-903](https://cwiki.apache.org/confluence/display/KAFKA/KIP-903%3A+Replicas+with+stale+broker+epoch+should+not+be+allowed+to+join+the+ISR), it updates the broker-side logic of how to store the replica epoch and how to fill in the AlterPartition request:

1. Stores the replica epoch into the cluster.ReplicaState. Each time when the broker receives the fetch request, it will update the replica sate.
2. The LeaderAndIsr now stores the ISR with their broker epoch.

https://issues.apache.org/jira/browse/KAFKA-14617